### PR TITLE
Make theme detection backwards compatible

### DIFF
--- a/src/vaadin-usage-statistics.js
+++ b/src/vaadin-usage-statistics.js
@@ -80,12 +80,6 @@ class StatisticsGatherer {
       }
     };
   };
-  getUsedVaadinElementVersion(elementName) {
-    const klass = customElements.get(elementName);
-    if (klass) {
-      return klass.version || "0.0.0";
-    }
-  }
   getUsedVaadinElements(elements) {
     const version = getPolymerVersion();
     let elementClasses;
@@ -106,10 +100,17 @@ class StatisticsGatherer {
       'Lumo',
       'Material'
     ].forEach(themeName => {
-      const elementName = `vaadin-${themeName.toLowerCase()}-styles`;
-      const version = this.getUsedVaadinElementVersion(elementName);
-      if (version) {
-        themes[themeName] = {version};
+      var theme;
+      var version = getPolymerVersion();
+      if (version && version.indexOf('2') === 0) {
+        // Polymer 2: themes are stored in window.Vaadin
+        theme = window.Vaadin[themeName];
+      } else {
+        // Polymer 3: themes are stored in custom element registry
+        theme = customElements.get(`vaadin-${themeName.toLowerCase()}-styles`);
+      }
+      if (theme && theme.version) {
+        themes[themeName] = {version: theme.version};
       }
     });
   }

--- a/test/usage.html
+++ b/test/usage.html
@@ -30,6 +30,21 @@
       }
     }
 
+    // define mock theme globally depending on Polymer version
+    const defineTheme = theme => {
+      const {name, version} = theme;
+      if (isPolymer2) {
+        window.Vaadin[name] = {version};
+      } else {
+        const themeClass = class extends HTMLElement {
+          static get version() {
+            return version;
+          }
+        }
+        customElements.define(`vaadin-${name.toLowerCase()}-styles`, themeClass);
+      }
+    }
+
     const defineClasses = function () {
       window.DummyLogger = class DummyLogger extends StatisticsLogger {
         _isDebug() {
@@ -195,20 +210,6 @@
         window.Vaadin = {};
         window.Vaadin.registrations = [];
       });
-      suiteSetup(() => {
-        class LumoStyles extends HTMLElement {
-          static get version() {
-            return "2.0.0-alpha5";
-          }
-        }
-        customElements.define('vaadin-lumo-styles', LumoStyles);
-        class MaterialStyles extends HTMLElement {
-          static get version() {
-            return "1.1.0-beta1";
-          }
-        }
-        customElements.define('vaadin-material-styles', MaterialStyles);
-      });
       test('element-without-version-found', function () {
         const stats = new UsageStatistics();
         defineElement({ is: "foo-element" });
@@ -268,6 +269,7 @@
         assert.closeTo(data.frameworks["Flow"].firstUsed, new Date().getTime(), 10000);
       });
       test('lumo-detected', function () {
+        defineTheme({name: 'Lumo', version: '2.0.0-alpha5'});
         const stats = new UsageStatistics();
         stats.gatherer.gather(stats.storage);
         const data = stats.storage.read();
@@ -276,6 +278,7 @@
         assert.closeTo(data.themes["Lumo"].firstUsed, new Date().getTime(), 10000);
       });
       test('material-detected', function () {
+        defineTheme({name: 'Material', version: '1.1.0-beta1'});
         const stats = new UsageStatistics();
         stats.gatherer.gather(stats.storage);
         const data = stats.storage.read();

--- a/vaadin-usage-statistics.html
+++ b/vaadin-usage-statistics.html
@@ -151,14 +151,6 @@ For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistic
         };
       }
     }, {
-      key: 'getUsedVaadinElementVersion',
-      value: function getUsedVaadinElementVersion(elementName) {
-        var klass = customElements.get(elementName);
-        if (klass) {
-          return klass.version || "0.0.0";
-        }
-      }
-    }, {
       key: 'getUsedVaadinElements',
       value: function getUsedVaadinElements(elements) {
         var version = getPolymerVersion();
@@ -182,13 +174,18 @@ For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistic
     }, {
       key: 'getUsedVaadinThemes',
       value: function getUsedVaadinThemes(themes) {
-        var _this = this;
-
         ['Lumo', 'Material'].forEach(function (themeName) {
-          var elementName = 'vaadin-' + themeName.toLowerCase() + '-styles';
-          var version = _this.getUsedVaadinElementVersion(elementName);
-          if (version) {
-            themes[themeName] = { version: version };
+          var theme;
+          var version = getPolymerVersion();
+          if (version && version.indexOf('2') === 0) {
+            // Polymer 2: themes are stored in window.Vaadin
+            theme = window.Vaadin[themeName];
+          } else {
+            // Polymer 3: themes are stored in custom element registry
+            theme = customElements.get('vaadin-' + themeName.toLowerCase() + '-styles');
+          }
+          if (theme && theme.version) {
+            themes[themeName] = { version: theme.version };
           }
         });
       }
@@ -376,14 +373,14 @@ For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistic
     createClass(UsageStatistics, [{
       key: 'maybeGatherAndSend',
       value: function maybeGatherAndSend() {
-        var _this2 = this;
+        var _this = this;
 
         if (localStorage.getItem(UsageStatistics.optOutKey)) {
           return;
         }
         this.gatherer.gather(this.storage);
         setTimeout(function () {
-          _this2.maybeSend();
+          _this.maybeSend();
         }, this.gatherDelay * 1000);
       }
     }, {


### PR DESCRIPTION
This should be only needed if someone forces 2.0.0 of usage-statistics with V10 versions of components and Lumo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-usage-statistics/29)
<!-- Reviewable:end -->
