### PR TITLE
Use single instance of usage statistics

### DIFF
--- a/src/vaadin-usage-statistics.js
+++ b/src/vaadin-usage-statistics.js
@@ -342,6 +342,7 @@ class UsageStatistics {
 }
 
 try {
+  window.Vaadin = window.Vaadin || {};
   window.Vaadin.usageStatistics = window.Vaadin.usageStatistics || new UsageStatistics();
   window.Vaadin.usageStatistics.maybeGatherAndSend();
 } catch (e) {

--- a/src/vaadin-usage-statistics.js
+++ b/src/vaadin-usage-statistics.js
@@ -342,7 +342,8 @@ class UsageStatistics {
 }
 
 try {
-  new UsageStatistics().maybeGatherAndSend();
+  window.Vaadin.usageStatistics = window.Vaadin.usageStatistics || new UsageStatistics();
+  window.Vaadin.usageStatistics.maybeGatherAndSend();
 } catch (e) {
   // Intentionally ignored as this is not a problem in the app being developed
 }

--- a/vaadin-usage-statistics.html
+++ b/vaadin-usage-statistics.html
@@ -466,7 +466,8 @@ For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistic
   }();
 
   try {
-    new UsageStatistics().maybeGatherAndSend();
+    window.Vaadin.usageStatistics = window.Vaadin.usageStatistics || new UsageStatistics();
+    window.Vaadin.usageStatistics.maybeGatherAndSend();
   } catch (e) {
     // Intentionally ignored as this is not a problem in the app being developed
   }

--- a/vaadin-usage-statistics.html
+++ b/vaadin-usage-statistics.html
@@ -466,6 +466,7 @@ For details and to opt-out, see https://github.com/vaadin/vaadin-usage-statistic
   }();
 
   try {
+    window.Vaadin = window.Vaadin || {};
     window.Vaadin.usageStatistics = window.Vaadin.usageStatistics || new UsageStatistics();
     window.Vaadin.usageStatistics.maybeGatherAndSend();
   } catch (e) {


### PR DESCRIPTION
As of now, we no longer wait for asynchrounous loading, and therefore subsequent invocations force new instances of `UsageStatistics` to be created and invoked. The only option to reuse the same instance for Polymer 3 would be storing it globally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-usage-statistics/30)
<!-- Reviewable:end -->
