### PR TITLE
Allow disabling usage statistics per project in addition to per machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,31 @@ Statistics are only gathered when the application is in [development mode](https
 
 ## Opting out
 
+### npm and Vaadin 14+ (using npm)
+
+Using npm, you can disable it for the machine by running
+```
+npm explore @vaadin/vaadin-usage-statistics -- npm run disable
+```
+or you can disable it for the project by adding
+```
+   "vaadin": { "disableUsageStatistics": true }
+```
+to your project `package.json` and running `npm install` again (remove `node_modules` if needed).
+
+You can verify this by checking that `vaadin-usage-statistics.js` contains an empty function.
+
+### Vaadin 10 - 14 (using Bower)
+
+Add to your pom.xml:
+```
+<dependency>
+  <groupId>org.webjars.bowergithub.vaadin</groupId>
+  <artifactId>vaadin-usage-statistics</artifactId>
+  <version>1.0.0-optout</version>
+</dependency>
+```
+
 ### Bower
 
 To opt-out from statistics, install the no-op version of the `vaadin-usage-statistics` package using
@@ -27,23 +52,5 @@ bower install --save vaadin/vaadin-usage-statistics#optout
 ```
 You can verify this by checking that `vaadin-usage-statistics.html` is empty.
 
-### npm
-
-If you are using npm, run the following command:
-```
-npm explore @vaadin/vaadin-usage-statistics -- npm run disable
-````
-You can verify this by checking that `vaadin-usage-statistics.js` contains empty function.
-
-### Java
-
-If you are using Java, add to your pom.xml:
-```
-<dependency>
-  <groupId>org.webjars.bowergithub.vaadin</groupId>
-  <artifactId>vaadin-usage-statistics</artifactId>
-  <version>1.0.0-optout</version>
-</dependency>
-```
 
 If you have any questions on the use of the statistics, please contact statistics@vaadin.com.

--- a/check.js
+++ b/check.js
@@ -1,12 +1,31 @@
 var fs = require('fs');
 
-if (process.env.npm_package_config_disabled) {
-  console.log(`
+const disabledForMachine = process.env.npm_package_config_disabled;
+let disabledForProject = false;
+
+if (fs.existsSync("../../../package.json")) {
+  const projectPackageJson = JSON.parse(fs.readFileSync("../../../package.json"));
+  if (projectPackageJson.vaadin && projectPackageJson.vaadin.disableUsageStatistics) {
+    disabledForProject = true;
+  }
+}
+
+if (disabledForMachine || disabledForProject) {
+  if (disabledForMachine) {
+    console.log(`
     You have disabled Vaadin development time usage statistics collection. To re-enable, run:
     npm explore @vaadin/vaadin-usage-statistics -- npm run enable
     For more details, see https://github.com/vaadin/vaadin-usage-statistics
-  `);
+`);
+  } else {
+    console.log(`
+    You have disabled Vaadin development time usage statistics collection. To re-enable, remove:
+    "vaadin": { "disableUsageStatistics": true }
+    from the project package.json
 
+    For more details, see https://github.com/vaadin/vaadin-usage-statistics
+`);
+  }
   try {
     fs.renameSync('vaadin-usage-statistics.js', 'vaadin-usage-statistics.js.bak');
   } catch (err) {
@@ -28,8 +47,12 @@ if (process.env.npm_package_config_disabled) {
   }
 } else {
   console.log(`
-    Vaadin collects development time usage statistics to improve this product. To opt-out, run:
+    Vaadin collects development time usage statistics to improve this product. To opt-out, either run:
     npm explore @vaadin/vaadin-usage-statistics -- npm run disable
+    to store disable statistics for the machine, or add
+    "vaadin": { "disableUsageStatistics": true }
+    to the project package.json and re-run npm install to disable statistics for the project.
+
     For more details, see https://github.com/vaadin/vaadin-usage-statistics
   `);
   /* restore backup files if previously disabled */


### PR DESCRIPTION
Fixes #35

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-usage-statistics/36)
<!-- Reviewable:end -->
