### PR TITLE
fix: revert using npm config in postinstall script

### DIFF
--- a/check.js
+++ b/check.js
@@ -1,9 +1,6 @@
 var fs = require('fs');
 
 const disabledForMachine = process.env.npm_package_config_disabled;
-const greetingLogged = process.env.npm_package_config_greeting_logged;
-const optoutLogged = process.env.npm_package_config_optout_logged;
-
 let disabledForProject = false;
 
 if (fs.existsSync("../../../package.json")) {
@@ -15,7 +12,7 @@ if (fs.existsSync("../../../package.json")) {
 
 if (disabledForMachine || disabledForProject) {
   if (disabledForMachine) {
-    !optoutLogged && console.log(`
+    console.log(`
     You have disabled Vaadin development time usage statistics collection. To re-enable, run:
     npm explore @vaadin/vaadin-usage-statistics -- npm run enable
     For more details, see https://github.com/vaadin/vaadin-usage-statistics
@@ -28,7 +25,7 @@ if (disabledForMachine || disabledForProject) {
     throw err;
   }
 } else {
-  !greetingLogged && console.log(`
+  console.log(`
     Vaadin collects development time usage statistics to improve this product. To opt-out, either run:
     npm explore @vaadin/vaadin-usage-statistics -- npm run disable
     to store disable statistics for the machine, or add

--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -4,6 +4,6 @@
     "\"license\": \"Apache-2.0\","
   ],
   "to": [
-    "\"license\": \"Apache-2.0\",\n\"scripts\": {\n\"postinstall\": \"node check.js && npm config set @vaadin/vaadin-usage-statistics:greeting-logged true\",\n\"disable\": \"npm config set @vaadin/vaadin-usage-statistics:disabled true && npm run postinstall && npm config set @vaadin/vaadin-usage-statistics:optout-logged true\",\n\"enable\": \"npm config set @vaadin/vaadin-usage-statistics:disabled false && npm config set @vaadin/vaadin-usage-statistics:greeting-logged false && npm config set @vaadin/vaadin-usage-statistics:optout-logged false && npm run postinstall\"\n},"
+    "\"license\": \"Apache-2.0\",\n\"scripts\": {\n\"postinstall\": \"node check.js\",\n\"disable\": \"npm config set @vaadin/vaadin-usage-statistics:disabled true && npm run postinstall\",\n\"enable\": \"npm config set @vaadin/vaadin-usage-statistics:disabled false && npm run postinstall\"\n},"
   ]
 }


### PR DESCRIPTION
Let's revert using `npm config set` in postinstall script, as it does not work with local Node.js installation in Flow. We need this released in 2.0.8 to get Flow fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-usage-statistics/41)
<!-- Reviewable:end -->
