### PR TITLE
fix: allow installation with --ignore-script

### DIFF
--- a/magi-p3-post.json
+++ b/magi-p3-post.json
@@ -1,9 +1,14 @@
 {
-  "files": ["package.json"],
+  "files": [
+    "package.json",
+    "vaadin-usage-statistics.js"
+  ],
   "from": [
-    "\"license\": \"Apache-2.0\","
+    "\"license\": \"Apache-2.0\",",
+    "import './vaadin-usage-statistics-collect.js';"
   ],
   "to": [
-    "\"license\": \"Apache-2.0\",\n\"scripts\": {\n\"postinstall\": \"node check.js\",\n\"disable\": \"npm config set @vaadin/vaadin-usage-statistics:disabled true && npm run postinstall\",\n\"enable\": \"npm config set @vaadin/vaadin-usage-statistics:disabled false && npm run postinstall\"\n},"
+    "\"license\": \"Apache-2.0\",\n\"scripts\": {\n\"postinstall\": \"node check.js\",\n\"disable\": \"npm config set @vaadin/vaadin-usage-statistics:disabled true && npm run postinstall\",\n\"enable\": \"npm config set @vaadin/vaadin-usage-statistics:disabled false && npm run postinstall\"\n},",
+    "export * from './vaadin-usage-statistics-collect.js';"
   ]
 }


### PR DESCRIPTION
Fixes #42

The workaround is to use `magi` post-processing so that if user disables "postinstall" script, the export would still work. Opt-out in that case can be still done separately if needed.

So this
```
import './vaadin-usage-statistics-collect.js';
```
would become this
```
export * from './vaadin-usage-statistics-collect.js';
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-usage-statistics/43)
<!-- Reviewable:end -->
