### PR TITLE
fix: avoid copying file on postinstall if possible

### DIFF
--- a/check.js
+++ b/check.js
@@ -34,11 +34,13 @@ if (disabledForMachine || disabledForProject) {
 
     For more details, see https://github.com/vaadin/vaadin-usage-statistics
   `);
-  try {
-    fs.copyFileSync('vaadin-usage-statistics-collect.js', 'vaadin-usage-statistics.js');
-  } catch (err) {
-    console.log('Error while copying file!');
-    throw err;
+  const stats = fs.readFileSync('vaadin-usage-statistics.js').toString();
+  if (stats.startsWith(`export * from './vaadin-usage-statistics-collect.js';`) === false) {
+    try {
+      fs.copyFileSync('vaadin-usage-statistics-collect.js', 'vaadin-usage-statistics.js');
+    } catch (err) {
+      console.log('Error while copying file!');
+      throw err;
+    }
   }
 }
-


### PR DESCRIPTION
Now when we have #43 implemented, copying the file is not always necessary.
Also in certain environments with file permission restrictions it might cause an error:

```
Error: EACCES: permission denied, copyfile 'vaadin-usage-statistics-collect.js' 
-> 'vaadin-usage-statistics.js'
```
So, by default we should read file contents and if everything is good, skip copy step.

Otherwise (i.e. when user wants to opt-in back after previously opted out) file will be copied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-usage-statistics/45)
<!-- Reviewable:end -->
