### PR TITLE
chore: set type to module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "test"
   },
   "main": "vaadin-usage-statistics.html",
+  "type": "module",
   "devDependencies": {
     "bower": "^1.8.2",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
The `type` property of `package.json` may be used by frontend tooling (e.g Webpack, Vite) in determining whether the package's entry point is a conventional CJS or ES module. If no property is specified, the entry point may be treated as a CJS module. As an illustration, here is a warning that Vite shows when you import `vaadin-usage-statistics`:

> @vaadin/vaadin-usage-statistics doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.

As long as Rollup converts `vaadin-usage-statistics` to an IIFE format, I assume the output bundle can be treated as a regular ES module so that it shouldn't be an issue if we set the `type` property to `module` that is needed to avoid possible misinterpretation.

Related to vaadin/flow#12574

## Type of change

- [x] Internal
